### PR TITLE
Fixed typo in basic_node.h

### DIFF
--- a/include/pam/basic_node.h
+++ b/include/pam/basic_node.h
@@ -53,7 +53,7 @@ struct basic_node {
   inline static ET* get_entry_p(node *a) {return &(a->entry);}
   static void set_entry(node *a, ET e) {a->entry = e;}
   static node* left(node a) {return a.lc;}
-  static node* right(node* a) {return a.rc;}
+  static node* right(node a) {return a.rc;}
 };
 
 //template <class E>


### PR DESCRIPTION
This typo was causing compilation issues in the example directory