### PR TITLE
Update utils.h

### DIFF
--- a/include/pam/utils.h
+++ b/include/pam/utils.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <optional>
 #include <string.h>
+#include "parlay/parallel.h"
 
 // *******************************************
 //   Utils


### PR DESCRIPTION
Add header file include to solve the following error:

```
/home/PAM/include/pam/utils.h: In function ‘std::pair<_FIter, _FIter> utils::fork(bool, Lf, Rf)’:
/home/PAM/include/pam/utils.h:30:15: error: ‘par_do’ is not a member of ‘parlay’
   30 |       parlay::par_do(do_left, do_right);
      |               ^~~~~~
```